### PR TITLE
Remove 10k per directory limitation

### DIFF
--- a/cloudfsapi.c
+++ b/cloudfsapi.c
@@ -4,7 +4,9 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <sys/stat.h>
+#ifdef __linux__
 #include <alloca.h>
+#endif
 #include <pthread.h>
 #include <time.h>
 #include <unistd.h>
@@ -258,7 +260,7 @@ int list_directory_internal(const char *path, dir_entry **dir_list)
   }
   if (*dir_list != NULL) {
     strcat(container, "&marker=");
-    strcat(container, (*dir_list)->name);
+    strcat(container, (*dir_list)->marker);
   }
   printf("%s\n", container);
   response = send_request("GET", container, NULL, xmlctx, NULL);
@@ -288,6 +290,7 @@ int list_directory_internal(const char *path, dir_entry **dir_list)
               de->name = strdup(strrchr(content, '/')+1);
             else
               de->name = strdup(content);
+            de->marker = strdup(content);
             if (asprintf(&(de->full_name), "%s/%s", path, de->name) < 0)
               de->full_name = NULL;
           }

--- a/cloudfsapi.h
+++ b/cloudfsapi.h
@@ -21,6 +21,7 @@ typedef struct dir_entry
   time_t last_modified;
   int isdir;
   struct dir_entry *next;
+  char *marker;
 } dir_entry;
 
 int object_read_fp(const char *path, FILE *fp);


### PR DESCRIPTION
So, I know that having 10k objects in a directory isn't a good idea! :-) But I've got to deal with this server/application as it is for the time being.

The Cloud Files limitation is 10k per result set.  My branch changes list_directory() to request the next set of objects if it gets exactly 10k results.

It does this by moving most of the functionality of list_directory() into list_directory_internal() with a slightly changed interface (the return value is the number of objects in the result set, and dir_list isn't cleared, it's used as the last item returned).  Then in list_directory() it calls list_directory_internal(), looping if necessary.

It's been a long time since I've written any C code, so I hope didn't do anything really stupid in there!  In any case, go easy on me. ;-)

Best regards,
David.
