### PR TITLE
alloca.h is a non standard header

### DIFF
--- a/cloudfsapi.c
+++ b/cloudfsapi.c
@@ -4,7 +4,9 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <sys/stat.h>
+#ifdef __linux__
 #include <alloca.h>
+#endif
 #include <pthread.h>
 #include <time.h>
 #include <unistd.h>


### PR DESCRIPTION
Its not present on many non Linux systems - this sets it to include it only on Linux.

Thanks
