### PR TITLE
Directory caching memory leak fix.

### DIFF
--- a/cloudfsapi.c
+++ b/cloudfsapi.c
@@ -321,6 +321,7 @@ void free_dir_list(dir_entry *dir_list)
     dir_entry *de = dir_list;
     dir_list = dir_list->next;
     free(de->name);
+    free(de->full_name);
     free(de->content_type);
     free(de);
   }


### PR DESCRIPTION
dir_entry were not freed properly causing some serious memory leakage especially on low cache_timeout.
