### PR TITLE
Bug fix for self-signed certificates

### DIFF
--- a/cloudfsapi.c
+++ b/cloudfsapi.c
@@ -127,6 +127,7 @@ static int send_request(char *method, const char *path, FILE *fp,
     curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
     curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, USER_AGENT);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, verify_ssl);
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, verify_ssl);
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10);
     curl_easy_setopt(curl, CURLOPT_VERBOSE, debug);


### PR DESCRIPTION
[softded@softded ~]$ ./cloudfuse/cloudfuse -d  verify_ssl=false username=test:test api_key=test authurl=https://auth.swift.agava.net/ swift/

```
!!! Sending authentication request.
* Adding handle: conn: 0x9711db8
* Adding handle: send: 0
* Adding handle: recv: 0
* Curl_addHandleToPipeline: length: 1
* - Conn 0 (0x9711db8) send_pipe: 1, recv_pipe: 0
* About to connect() to auth.swift.agava.net port 443 (#0)
*   Trying 89.108.66.19...
* Connected to auth.swift.agava.net (89.108.66.19) port 443 (#0)
* Initializing NSS with certpath: sql:/etc/pki/nssdb
* skipping SSL peer certificate verification
* SSL connection using TLS_DHE_RSA_WITH_AES_128_CBC_SHA
* Server certificate:
*       subject: E=softded@agava.com,CN=swift.agava.net,O=AGAVA,L=Moscow,ST=Russia,C=RU
*       start date: Mar 17 08:24:37 2014 GMT
*       expire date: Apr 16 08:24:37 2014 GMT
*       common name: swift.agava.net
*       issuer: E=softded@agava.com,CN=swift.agava.net,O=AGAVA,L=Moscow,ST=Russia,C=RU
> GET / HTTP/1.1
User-Agent: CloudFuse
Host: auth.swift.agava.net
Accept: */*
X-Auth-User: test:test
X-Auth-Key: test

< HTTP/1.1 200 OK
* Server nginx/1.4.1 (Ubuntu) is not blacklisted
< Server: nginx/1.4.1 (Ubuntu)
< Date: Thu, 03 Apr 2014 16:28:28 GMT
< Content-Length: 87
< Connection: keep-alive
< X-Storage-Url: https://store1.swift.agava.net/AUTH_test
< X-Storage-Token: AUTH_tkab2d4bb1c2a546da985b4f44a3f160e3
< X-Auth-Token: AUTH_tkab2d4bb1c2a546da985b4f44a3f160e3
< X-Trans-Id: tx8afdb27cfa3a4709b6ded-00533d8c2c
< 
```

On 'ls' command:

```
unique: 2, opcode: GETATTR (3), nodeid: 1, insize: 56, pid: 12607
getattr /
   unique: 2, success, outsize: 120
unique: 3, opcode: OPENDIR (27), nodeid: 1, insize: 48, pid: 12607
   unique: 3, success, outsize: 32
unique: 4, opcode: READDIR (28), nodeid: 1, insize: 80, pid: 12607
readdir[0] from 0
* Adding handle: conn: 0xb6d15990
* Adding handle: send: 0
* Adding handle: recv: 0
* Curl_addHandleToPipeline: length: 1
* - Conn 1 (0xb6d15990) send_pipe: 1, recv_pipe: 0
* About to connect() to store1.swift.agava.net port 443 (#1)
*   Trying 89.108.66.19...
* Connected to store1.swift.agava.net (89.108.66.19) port 443 (#1)
*   CAfile: /etc/pki/tls/certs/ca-bundle.crt
  CApath: none
* Server certificate:
*       subject: E=softded@agava.com,CN=swift.agava.net,O=AGAVA,L=Moscow,ST=Russia,C=RU
*       start date: Mar 17 08:24:37 2014 GMT
*       expire date: Apr 16 08:24:37 2014 GMT
*       common name: swift.agava.net
*       issuer: E=softded@agava.com,CN=swift.agava.net,O=AGAVA,L=Moscow,ST=Russia,C=RU
* NSS error -8172 (SEC_ERROR_UNTRUSTED_ISSUER)
* Peer's certificate issuer has been marked as not trusted by the user.
* Closing connection 1
```