### PR TITLE
Feature: header specification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,13 @@ config.status
 
 # Binary outputs
 cloudfuse
+test/specrunner
 
 # Ignore Eclipse files
 .cproject
 .project
 
+# Misc dev files
 TAGS
+**/*~
+

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ cloudfuse
 # Ignore Eclipse files
 .cproject
 .project
+
+TAGS

--- a/Makefile.in
+++ b/Makefile.in
@@ -11,8 +11,10 @@ prefix = @prefix@
 exec_prefix = @exec_prefix@
 bindir = $(DESTDIR)$(exec_prefix)/bin
 
-SOURCES=cloudfsapi.c cloudfuse.c
-HEADERS=cloudfsapi.h
+SOURCES=cloudfsapi.c cloudfuse.c headerspec.c
+HEADERS=cloudfsapi.h headerspec.h
+
+TESTS=test/header01
 
 all: cloudfuse
 
@@ -27,6 +29,9 @@ $(bindir):
 
 cloudfuse: $(SOURCES) $(HEADERS)
 	$(CC) $(CFLAGS) -o cloudfuse $(SOURCES) $(LIBS)
+
+test/specrunner: $(SOURCES) $(HEADERS) test/specrunner.c
+	$(CC) $(CFLAGS) -o test/specrunner test/specrunner.c headerspec.c cloudfsapi.c $(LIBS)
 
 clean:
 	/bin/rm -f cloudfuse
@@ -52,3 +57,7 @@ Makefile: Makefile.in config.status
 config.status: configure
 	./config.status --recheck
 
+tests: test/specrunner
+	for test in $(TESTS); do \
+		$$test || exit 1; \
+	done

--- a/Makefile.in
+++ b/Makefile.in
@@ -61,3 +61,6 @@ tests: test/specrunner
 	for test in $(TESTS); do \
 		$$test || exit 1; \
 	done
+
+etags:
+	etags $$(ls *.[hc]) /usr/include/fuse/fuse.h /usr/include/fuse/fuse_opt.h /usr/include/curl/curl.h

--- a/Makefile.in
+++ b/Makefile.in
@@ -14,7 +14,10 @@ bindir = $(DESTDIR)$(exec_prefix)/bin
 SOURCES=cloudfsapi.c cloudfuse.c headerspec.c
 HEADERS=cloudfsapi.h headerspec.h
 
-TESTS=test/header01
+TESTS=test/header01 \
+	test/header02 \
+	test/header03 \
+	test/header04
 
 all: cloudfuse
 

--- a/README
+++ b/README
@@ -117,9 +117,8 @@ HEADER SPECIFICATIONS:
 
     EM notes:
     - TODO:
-      - more tests
       - disable feature in configure
-      - ensure bad parse fails the mount with good feedback
+      - GNU brace style
 
 BUGS/SHORTCOMINGS:
 

--- a/README
+++ b/README
@@ -100,7 +100,7 @@ HEADER SPECIFICATIONS:
     Content-Type header.  Rackspace's CloudFiles, for example, allows
     14 different headers for specifying access controls, content
     expiration, and content encoding.  Cloudfuse doesn't restrict what
-    headers can be specified, so use carefully.
+    headers can be specified, so use this feature carefully.
 
     The header value is set based on matching a path against a list of
     globs.  Here's an example which sets the Content-Type header:
@@ -111,11 +111,14 @@ HEADER SPECIFICATIONS:
     double quotes can be used to specify a pattern that has spaces.
     Multiple headers can be specified, separated by semicolon (;)
 
+    The path looks like an absolute path beginning at the mount point.
+    For example, a file "index.html" in bucket "foo" will result in
+    the string "/foo/index.html" being matched against the glob pattern.
+
     EM notes:
     - TODO:
       - more tests
       - disable feature in configure
-      - factor out printf
       - ensure bad parse fails the mount with good feedback
 
 BUGS/SHORTCOMINGS:

--- a/README
+++ b/README
@@ -112,16 +112,11 @@ HEADER SPECIFICATIONS:
     Multiple headers can be specified, separated by semicolon (;)
 
     EM notes:
-    - Need ** for recursive matching e.g. **/*.html ?  What does git use if not fnmatch()?
-    - Need ! for full pattern negation ?
-    - Disable feature in configure.ac
-    - Need flex or lex?  Can probably use wcstok with separators ":,; "
-    - Need tests
-    - Need a way to report errors (and fail the mount)
-    - implement hooks
-      - cfs_flush triggers the PUT
-      - bogus content type configured in update_dir_cache
-      - content_type is special since it's tracked in the dir cache
+    - TODO:
+      - more tests
+      - disable feature in configure
+      - factor out printf
+      - ensure bad parse fails the mount with good feedback
 
 BUGS/SHORTCOMINGS:
 
@@ -148,7 +143,7 @@ AWESOME CONTRIBUTORS:
     * David Brownlee                               https://github.com/abs0
     * Mike Lundy                                   https://github.com/novas0x2a
     * justinb                                      https://github.com/justinsb
-
+    * Erik Mackdanz                                http://mackdanz.net
 
 Thanks, and I hope you find it useful.
 

--- a/README
+++ b/README
@@ -100,25 +100,30 @@ HEADER SPECIFICATIONS:
     Content-Type header.  Rackspace's CloudFiles, for example, allows
     14 different headers for specifying access controls, content
     expiration, and content encoding.  Cloudfuse doesn't restrict what
-    headers can be specified, so use this feature carefully.
+    headers can be specified.
 
     The header value is set based on matching a path against a list of
-    globs.  Here's an example which sets the Content-Type header:
+    globs.  The syntax:
+
+      HeaderKey: GlobMatch HeaderValue [, GlobMatch HeaderValue...] [; HeaderKey...]
+
+    Here's an example which sets the Content-Type header:
 
       Content-Type: /foobucket/*.html text/html, "/*/my dir/*.txt" text/plain;
 
     If no pattern matches, then the header is omitted.  Note that
     double quotes can be used to specify a pattern that has spaces.
     Multiple headers can be specified, separated by semicolon (;)
+    More examples are available in the test directory.
+
+    See 'man 3 fnmatch' for accepted glob patterns.
 
     The path looks like an absolute path beginning at the mount point.
     For example, a file "index.html" in bucket "foo" will result in
-    the string "/foo/index.html" being matched against the glob pattern.
+    the string "/foo/index.html" being matched against the glob
+    pattern (even if the absolute path on your system is actually
+    /var/www/foo/index.html).
 
-    EM notes:
-    - TODO:
-      - disable feature in configure
-      - GNU brace style
 
 BUGS/SHORTCOMINGS:
 

--- a/README
+++ b/README
@@ -93,6 +93,36 @@ EXAMPLE:
         authurl=http://10.10.0.1:5000/v2.0
 
 
+HEADER SPECIFICATIONS:
+
+    The option headers_spec option allows to specify headers to send
+    when a file is written.  A common use is to specify the
+    Content-Type header.  Rackspace's CloudFiles, for example, allows
+    14 different headers for specifying access controls, content
+    expiration, and content encoding.  Cloudfuse doesn't restrict what
+    headers can be specified, so use carefully.
+
+    The header value is set based on matching a path against a list of
+    globs.  Here's an example which sets the Content-Type header:
+
+      Content-Type: /foobucket/*.html text/html, "/*/my dir/*.txt" text/plain;
+
+    If no pattern matches, then the header is omitted.  Note that
+    double quotes can be used to specify a pattern that has spaces.
+    Multiple headers can be specified, separated by semicolon (;)
+
+    EM notes:
+    - Need ** for recursive matching e.g. **/*.html ?  What does git use if not fnmatch()?
+    - Need ! for full pattern negation ?
+    - Disable feature in configure.ac
+    - Need flex or lex?  Can probably use wcstok with separators ":,; "
+    - Need tests
+    - Need a way to report errors (and fail the mount)
+    - implement hooks
+      - cfs_flush triggers the PUT
+      - bogus content type configured in update_dir_cache
+      - content_type is special since it's tracked in the dir cache
+
 BUGS/SHORTCOMINGS:
 
     * rename() doesn't work on directories (and probably never will).

--- a/cloudfsapi.c
+++ b/cloudfsapi.c
@@ -253,7 +253,7 @@ int cloudfs_object_read_fp(const char *path, FILE *fp)
   rewind(fp);
   char *encoded = curl_escape(path, 0);
   curl_slist *headers = NULL;
-  add_matching_headers(add_header,&headers,hspec,path);
+  add_matching_headers(&headers,hspec,path);
   int response = send_request("PUT", encoded, fp, NULL, headers);
   curl_free(encoded);
   curl_slist_free_all(headers);

--- a/cloudfsapi.c
+++ b/cloudfsapi.c
@@ -84,8 +84,8 @@ static void return_connection(CURL *curl)
   pthread_mutex_unlock(&pool_mut);
 }
 
-static void add_header(curl_slist **headers, const char *name,
-                       const char *value)
+void add_header(curl_slist **headers, const char *name,
+		const char *value)
 {
   char x_header[MAX_HEADER_SIZE];
   snprintf(x_header, sizeof(x_header), "%s: %s", name, value);

--- a/cloudfsapi.c
+++ b/cloudfsapi.c
@@ -249,7 +249,6 @@ void cloudfs_init()
 
 int cloudfs_object_read_fp(const char *path, FILE *fp)
 {
-  debugf("In cloudfs_object_read_fp");
   fflush(fp);
   rewind(fp);
   char *encoded = curl_escape(path, 0);
@@ -442,7 +441,6 @@ int cloudfs_delete_object(const char *path)
 
 int cloudfs_copy_object(const char *src, const char *dst)
 {
-  debugf("In cloudfs_copy_object");
   char *dst_encoded = curl_escape(dst, 0);
   curl_slist *headers = NULL;
   add_header(&headers, "X-Copy-From", src);
@@ -505,7 +503,8 @@ void cloudfs_set_credentials(char *username, char *tenant, char *password,
   reconnect_args.use_snet = use_snet;
 }
 
-void cloudfs_set_header_spec(header_spec *spec) {
+void cloudfs_set_header_spec(header_spec *spec)
+{
   hspec = spec;
 }
 

--- a/cloudfsapi.h
+++ b/cloudfsapi.h
@@ -3,6 +3,7 @@
 
 #include <curl/curl.h>
 #include <curl/easy.h>
+#include "headerspec.h"
 
 #define BUFFER_INITIAL_SIZE 4096
 #define MAX_HEADER_SIZE 8192
@@ -38,6 +39,7 @@ off_t cloudfs_file_size(int fd);
 void cloudfs_debug(int dbg);
 void cloudfs_verify_ssl(int dbg);
 void cloudfs_free_dir_list(dir_entry *dir_list);
+void cloudfs_set_header_spec(header_spec *spec);
 void add_header(curl_slist **headers, const char *name,
 		const char *value);
 

--- a/cloudfsapi.h
+++ b/cloudfsapi.h
@@ -38,6 +38,8 @@ off_t cloudfs_file_size(int fd);
 void cloudfs_debug(int dbg);
 void cloudfs_verify_ssl(int dbg);
 void cloudfs_free_dir_list(dir_entry *dir_list);
+void add_header(curl_slist **headers, const char *name,
+		const char *value);
 
 void debugf(char *fmt, ...);
 #endif

--- a/cloudfuse.c
+++ b/cloudfuse.c
@@ -505,7 +505,11 @@ int main(int argc, char **argv)
   cloudfs_init();
 
   header_spec *parsed = NULL;
-  parse_spec(options.header_spec, &parsed);
+  if(!parse_spec(options.header_spec, &parsed))
+  {
+    fprintf(stderr, "Could not parse header spec\n");
+    return 1;
+  }
   cloudfs_set_header_spec(parsed);
 
   cloudfs_verify_ssl(!strcasecmp(options.verify_ssl, "true"));

--- a/cloudfuse.c
+++ b/cloudfuse.c
@@ -433,6 +433,7 @@ static struct options {
     char region[OPTION_SIZE];
     char use_snet[OPTION_SIZE];
     char verify_ssl[OPTION_SIZE];
+    char header_spec[OPTION_SIZE*10];
 } options = {
     .username = "",
     .password = "",
@@ -442,6 +443,7 @@ static struct options {
     .region = "",
     .use_snet = "false",
     .verify_ssl = "true",
+    .header_spec = ""
 };
 
 int parse_option(void *data, const char *arg, int key, struct fuse_args *outargs)
@@ -454,7 +456,8 @@ int parse_option(void *data, const char *arg, int key, struct fuse_args *outargs
       sscanf(arg, " authurl = %[^\r\n ]", options.authurl) ||
       sscanf(arg, " region = %[^\r\n ]", options.region) ||
       sscanf(arg, " use_snet = %[^\r\n ]", options.use_snet) ||
-      sscanf(arg, " verify_ssl = %[^\r\n ]", options.verify_ssl))
+      sscanf(arg, " verify_ssl = %[^\r\n ]", options.verify_ssl) ||
+      sscanf(arg, " header_spec = %[^\r\n]", options.header_spec)) // Note spaces permitted
     return 0;
   if (!strcmp(arg, "-f") || !strcmp(arg, "-d") || !strcmp(arg, "debug"))
     cloudfs_debug(1);
@@ -494,11 +497,16 @@ int main(int argc, char **argv)
     fprintf(stderr, "  use_snet=[True to use Rackspace ServiceNet for connections]\n");
     fprintf(stderr, "  cache_timeout=[Seconds for directory caching, default 600]\n");
     fprintf(stderr, "  verify_ssl=[False to disable SSL cert verification]\n");
+    fprintf(stderr, "  header_spec=[Match specification for writing extra headers, see README]\n");
 
     return 1;
   }
 
   cloudfs_init();
+
+  header_spec *parsed = NULL;
+  parse_spec(options.header_spec, &parsed);
+  cloudfs_set_header_spec(parsed);
 
   cloudfs_verify_ssl(!strcasecmp(options.verify_ssl, "true"));
 
@@ -541,5 +549,7 @@ int main(int argc, char **argv)
 
   pthread_mutex_init(&dmut, NULL);
   return fuse_main(args.argc, args.argv, &cfs_oper, &options);
+
+  free_spec(parsed);
 }
 

--- a/cloudfuse.c
+++ b/cloudfuse.c
@@ -16,7 +16,7 @@
 #include <stddef.h>
 #include "cloudfsapi.h"
 #include "config.h"
-
+#include "headerspec.h"
 
 #define OPTION_SIZE 1024
 

--- a/headerspec.c
+++ b/headerspec.c
@@ -1,0 +1,252 @@
+#include <stdlib.h>
+#include <string.h>
+#include <fnmatch.h>
+#include "headerspec.h"
+
+static int next_token(const char *spec /* in */, int *scanstart /* in/out */,
+		      int *tokenstart /* out */, int *tokenlen /* out */) {
+
+  const char *start = spec + *scanstart;
+  const char *thisc = start;
+
+  // skip any leading whitespace
+  while(*thisc==' ' || *thisc=='\t' || *thisc=='\n' || *thisc=='\r') {
+    thisc++;
+  }
+
+  // detect end of input
+  if(!*thisc) return 0;
+
+  // Handle quote
+  if(*thisc=='"') {
+    thisc++;
+    *tokenstart = thisc - spec;
+    while(1) {
+      if(*thisc == '"') {
+	*tokenlen = (thisc - spec) - *tokenstart;
+	*scanstart = *tokenstart + *tokenlen + 1; // trim trailing "
+	return 1;
+      } else if(*thisc == 0) { // Handle unterminated string
+	*tokenlen = (thisc - spec) - *tokenstart;
+	*scanstart = *tokenstart + *tokenlen;
+	return 0;
+      }
+      thisc++;
+    }
+  } else if(*thisc==':') {
+    *tokenstart = thisc - spec;
+    *tokenlen = 1;
+    *scanstart = *tokenstart + *tokenlen;
+    return 1;
+  } else if(*thisc==';') {
+    *tokenstart = thisc - spec;
+    *tokenlen = 1;
+    *scanstart = *tokenstart + *tokenlen;
+    return 1;
+  } else if(*thisc==',') {
+    *tokenstart = thisc - spec;
+    *tokenlen = 1;
+    *scanstart = *tokenstart + *tokenlen;
+    return 1;
+  } else if(*thisc=='!') {
+    *tokenstart = thisc - spec;
+    *tokenlen = 1;
+    *scanstart = *tokenstart + *tokenlen;
+    return 1;
+  } else { // An actual token
+    *tokenstart = thisc - spec;
+
+    while(1) {
+      thisc++;
+      if(*thisc==' ' || *thisc=='\t' || *thisc=='\n' || *thisc=='\r' || *thisc=='"'
+	 || *thisc==':' || *thisc==';' || *thisc==',' || *thisc=='!') break;
+    }
+    
+    *tokenlen = (thisc - spec) - *tokenstart;
+    *scanstart = *tokenstart + *tokenlen;
+
+    return 1;
+  }
+}
+
+static enum {
+  EXPECT_EOF_OR_SEMI_OR_HEADERKEY,
+  EXPECT_COLON,
+  EXPECT_NEGATE_OR_MATCH,
+  EXPECT_MATCH,
+  EXPECT_HEADER_VALUE,
+  EXPECT_EOF_OR_COMMA_OR_SEMI
+} parse_states;
+
+int parse_spec(const char *spec, header_spec **output) {
+
+  int scanstart = 0;
+  int tokenstart, tokenlen;
+
+  int state = EXPECT_EOF_OR_SEMI_OR_HEADERKEY;
+  while(next_token(spec,&scanstart,&tokenstart,&tokenlen)) {
+    /* printf("Found token at %d len %d\n",tokenstart,tokenlen); */
+
+    char fc = *(spec+tokenstart); // first char of token
+
+    char *headerkey, *pattern, *headervalue;
+    int isnegated;
+    header_spec *speclist_tail;
+
+    switch(state) {
+    case EXPECT_EOF_OR_SEMI_OR_HEADERKEY:
+      if(';' == fc) continue;
+      if(':'==fc || '!'==fc || ','==fc) {
+	printf("In state %d, encountered unexpected token at %d len %d\n",state,tokenstart,tokenlen);
+	return 0;
+      }
+      headerkey = strndup(spec+tokenstart,tokenlen);
+      printf("Header key is %s\n",headerkey);
+
+      // Create a new tail for the linked list.
+      speclist_tail = *output;
+      if(speclist_tail) {
+	while(speclist_tail->next) {
+	  speclist_tail = speclist_tail->next;
+	}
+	speclist_tail->next = malloc(sizeof(header_spec));
+	speclist_tail = speclist_tail->next;
+      } else { // special case for first list element
+	*output = malloc(sizeof(header_spec));
+	speclist_tail = *output;
+      }
+
+      speclist_tail->header_key = headerkey;
+      speclist_tail->matches = NULL;
+      speclist_tail->next = NULL;
+
+      state = EXPECT_COLON;
+      break;
+    case EXPECT_COLON:
+      if(':'!=fc) {
+	printf("In state %d, encountered unexpected token at %d len %d\n",state,tokenstart,tokenlen);
+	return 0;
+      }
+      state = EXPECT_NEGATE_OR_MATCH;
+      break;
+    case EXPECT_NEGATE_OR_MATCH:
+      isnegated = 0;
+      if('!'==fc) {
+	printf("Match is negated\n");
+	isnegated = 1;
+	state = EXPECT_MATCH;
+      } else if(':'==fc || ','==fc || ';'==fc) {
+	printf("In state %d, encountered unexpected token at %d len %d\n",state,tokenstart,tokenlen);
+	return 0;
+      } else {
+	pattern = strndup(spec+tokenstart,tokenlen);
+	printf("Pattern is %s\n",pattern);
+	state = EXPECT_HEADER_VALUE;
+      }
+      break;
+    case EXPECT_MATCH:
+      if(':'==fc || '!'==fc || ','==fc || ';'==fc) {
+	printf("In state %d, encountered unexpected token at %d len %d\n",state,tokenstart,tokenlen);
+	return 0;
+      }
+      pattern = strndup(spec+tokenstart,tokenlen);
+      printf("Pattern is %s\n",pattern);
+      state = EXPECT_HEADER_VALUE;
+      break;
+    case EXPECT_HEADER_VALUE:
+      if(':'==fc || '!'==fc || ','==fc || ';'==fc) {
+	printf("In state %d, encountered unexpected token at %d len %d\n",state,tokenstart,tokenlen);
+	return 0;
+      }
+      headervalue = strndup(spec+tokenstart,tokenlen);
+      printf("Header value is %s\n",headervalue);
+
+      match_spec *matchlist_tail;
+      if(speclist_tail->matches) {
+	matchlist_tail = speclist_tail->matches;
+	while(matchlist_tail->next) {
+	  matchlist_tail = matchlist_tail->next;
+	}
+	matchlist_tail->next = malloc(sizeof(match_spec));
+	matchlist_tail = matchlist_tail->next;
+      } else {
+	matchlist_tail = malloc(sizeof(match_spec));
+	speclist_tail->matches = matchlist_tail;
+      }
+
+      matchlist_tail->next = NULL;
+      matchlist_tail->pattern = pattern;
+      matchlist_tail->is_positive = !isnegated;
+      matchlist_tail->header_value = headervalue;
+
+      state = EXPECT_EOF_OR_COMMA_OR_SEMI;
+      break;
+    case EXPECT_EOF_OR_COMMA_OR_SEMI:
+      if(','==fc) {
+	state=EXPECT_NEGATE_OR_MATCH;
+      } else if(';'==fc) {
+	state=EXPECT_EOF_OR_SEMI_OR_HEADERKEY;
+      } else {
+	printf("In state %d, encountered unexpected token at %d len %d\n",state,tokenstart,tokenlen);
+	return 0;
+      }
+      break;
+    default:
+      printf("In unexpected state %d with token at %d len %d\n",state,tokenstart,tokenlen);
+      return 0;
+    }
+  }
+
+  if(state != EXPECT_EOF_OR_SEMI_OR_HEADERKEY && state != EXPECT_EOF_OR_COMMA_OR_SEMI) {
+    printf("Finished parse in unexpected state %d\n",state);
+    return 0;
+  }
+
+  return 1;
+}
+
+void free_spec(header_spec *spec) {
+  if(!spec) return;
+
+  /* printf("Freeing spec at %p\n",spec); */
+  free(spec->header_key);
+
+  // free matches;
+  match_spec *onematch = spec->matches;
+  while(onematch) {
+    /* printf("Freeing match with value %s\n",onematch->header_value); */
+    free(onematch->pattern);
+    free(onematch->header_value);
+    match_spec *nextmatch = onematch->next;
+    free(onematch);
+    onematch = nextmatch;
+  }
+
+  header_spec *next = spec->next;
+  free(spec);
+  free_spec(next);
+}
+
+
+  
+int add_matching_headers(void (add_header_func)(struct curl_slist **headers, const char *name, const char *value),
+			 struct curl_slist **headers, header_spec *spec, const char *path) {
+
+  header_spec *onespec = spec;
+  while(onespec) {
+
+    match_spec *onematch = onespec->matches;
+    while(onematch) {
+
+      int result = fnmatch(onematch->pattern,path,0);
+      if(!result) {
+	add_header_func(headers,onespec->header_key,onematch->header_value);
+	break;
+      }
+      onematch = onematch->next;
+    }
+
+    onespec = onespec->next;
+  }
+
+}

--- a/headerspec.c
+++ b/headerspec.c
@@ -244,8 +244,11 @@ int add_matching_headers(void (add_header_func)(struct curl_slist **headers, con
 
       int result = fnmatch(onematch->pattern,path,0);
       debugf("Testing one match, path being %s, result was %d\n",path,result);
-      if(!result) {
+      if((result==0 && onematch->is_positive) || (result==FNM_NOMATCH && !onematch->is_positive)) {
 	add_header_func(headers,onespec->header_key,onematch->header_value);
+	break;
+      } else if(result!=0 && result != FNM_NOMATCH) {
+	debugf("fnmatch error\n");
 	break;
       }
       onematch = onematch->next;

--- a/headerspec.c
+++ b/headerspec.c
@@ -279,8 +279,7 @@ void free_spec(header_spec *spec)
   free_spec(next);
 }
 
-int add_matching_headers(void (add_header_func)(struct curl_slist **headers, const char *name, const char *value),
-			 struct curl_slist **headers, header_spec *spec, const char *path)
+int add_matching_headers(struct curl_slist **headers, header_spec *spec, const char *path)
 {
 
   header_spec *onespec = spec;
@@ -294,7 +293,7 @@ int add_matching_headers(void (add_header_func)(struct curl_slist **headers, con
       debugf("Testing one match, path being %s, result was %d\n",path,result);
       if((result==0 && onematch->is_positive) || (result==FNM_NOMATCH && !onematch->is_positive))
       {
-	add_header_func(headers,onespec->header_key,onematch->header_value);
+	add_header(headers,onespec->header_key,onematch->header_value);
 	break;
       }
       else if(result!=0 && result != FNM_NOMATCH)

--- a/headerspec.c
+++ b/headerspec.c
@@ -59,7 +59,7 @@ static int next_token(const char *spec /* in */, int *scanstart /* in/out */,
     while(1) {
       thisc++;
       if(*thisc==' ' || *thisc=='\t' || *thisc=='\n' || *thisc=='\r' || *thisc=='"'
-	 || *thisc==':' || *thisc==';' || *thisc==',' || *thisc=='!') break;
+	 || *thisc==':' || *thisc==';' || *thisc==',' || *thisc=='!' || *thisc==0) break;
     }
     
     *tokenlen = (thisc - spec) - *tokenstart;
@@ -80,12 +80,14 @@ static enum {
 
 int parse_spec(const char *spec, header_spec **output) {
 
+  printf("Entire spec is %s\n",spec);
+
   int scanstart = 0;
   int tokenstart, tokenlen;
 
   int state = EXPECT_EOF_OR_SEMI_OR_HEADERKEY;
   while(next_token(spec,&scanstart,&tokenstart,&tokenlen)) {
-    /* printf("Found token at %d len %d\n",tokenstart,tokenlen); */
+    printf("Found token at %d len %d\n",tokenstart,tokenlen);
 
     char fc = *(spec+tokenstart); // first char of token
 
@@ -116,6 +118,7 @@ int parse_spec(const char *spec, header_spec **output) {
 	speclist_tail = *output;
       }
 
+      printf("Allocated speclist\n");
       speclist_tail->header_key = headerkey;
       speclist_tail->matches = NULL;
       speclist_tail->next = NULL;
@@ -202,6 +205,7 @@ int parse_spec(const char *spec, header_spec **output) {
     return 0;
   }
 
+  printf("Parse completed successfully\n");
   return 1;
 }
 
@@ -227,18 +231,18 @@ void free_spec(header_spec *spec) {
   free_spec(next);
 }
 
-
-  
 int add_matching_headers(void (add_header_func)(struct curl_slist **headers, const char *name, const char *value),
 			 struct curl_slist **headers, header_spec *spec, const char *path) {
 
   header_spec *onespec = spec;
   while(onespec) {
 
+    printf("Testing one spec\n");
     match_spec *onematch = onespec->matches;
     while(onematch) {
 
       int result = fnmatch(onematch->pattern,path,0);
+      printf("Testing one match, path being %s, result was %d\n",path,result);
       if(!result) {
 	add_header_func(headers,onespec->header_key,onematch->header_value);
 	break;

--- a/headerspec.h
+++ b/headerspec.h
@@ -3,14 +3,16 @@
 
 #include <curl/curl.h>
 
-typedef struct match_spec {
+typedef struct match_spec
+{
   char *pattern;
   int is_positive;
   char *header_value;
   struct match_spec *next;
 } match_spec;
 
-typedef struct header_spec {
+typedef struct header_spec
+{
   char *header_key;
   match_spec *matches;
   struct header_spec *next;

--- a/headerspec.h
+++ b/headerspec.h
@@ -1,0 +1,26 @@
+#ifndef _HEADERSPEC_H
+#define _HEADERSPEC_H
+
+#include <curl/curl.h>
+
+typedef struct match_spec {
+  char *pattern;
+  int is_positive;
+  char *header_value;
+  struct match_spec *next;
+} match_spec;
+
+typedef struct header_spec {
+  char *header_key;
+  match_spec *matches;
+  struct header_spec *next;
+} header_spec;
+
+int parse_spec(const char *spec, header_spec **output);
+
+int add_matching_headers(void (add_header_func)(struct curl_slist **headers, const char *name, const char *value),
+			 struct curl_slist **headers, header_spec *spec, const char *path);
+
+void free_spec(header_spec *spec);
+
+#endif // _HEADERSPEC_H

--- a/headerspec.h
+++ b/headerspec.h
@@ -20,8 +20,7 @@ typedef struct header_spec
 
 int parse_spec(const char *spec, header_spec **output);
 
-int add_matching_headers(void (add_header_func)(struct curl_slist **headers, const char *name, const char *value),
-			 struct curl_slist **headers, header_spec *spec, const char *path);
+int add_matching_headers(struct curl_slist **headers, header_spec *spec, const char *path);
 
 void free_spec(header_spec *spec);
 

--- a/test/header01
+++ b/test/header01
@@ -1,6 +1,16 @@
 #!/bin/sh
 
-exec test/specrunner \
-'Content-Type: *.jpg image/jpeg, ! *.html text/plain, * text/html; Content-Disposition: * "attachment; filename=foo.txt"' \
-/bar.html
+set -e
+set -x
+
+result=$(mktemp)
+
+test/specrunner \
+'Content-Type: *.jpg image/jpeg, ! *.txt text/html; Content-Disposition: * "attachment; filename=foo.txt"' \
+/bar.html >$result
+
+grep "Content-Type: text/html" $result
+grep "Content-Disposition: attachment; filename=foo.txt" $result
+
+rm $result
 

--- a/test/header01
+++ b/test/header01
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+exec test/specrunner \
+'Content-Type: *.jpg image/jpeg, ! *.html text/plain, * text/html; Content-Disposition: * "attachment; filename=foo.txt"' \
+/bar.html
+

--- a/test/header02
+++ b/test/header02
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+set -x
+
+result=$(mktemp)
+
+test/specrunner \
+'Content-Type: *.css text/css, /blog/code/*/repository/raw/* text/plain, /blog/code/* text/html' \
+/blog/code/foo >$result
+
+grep "Content-Type: text/html" $result
+
+rm $result
+
+

--- a/test/header03
+++ b/test/header03
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+set -x
+
+result=$(mktemp)
+
+test/specrunner \
+'Content-Type: *.css text/css, /blog/code/*/repository/raw/* text/plain, /blog/code/* text/html; Content-Disposition: * bar' \
+/foo >$result
+
+grep "Content-Disposition: bar" $result
+
+rm $result
+
+

--- a/test/header04
+++ b/test/header04
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+set -x
+
+# Ensure bad parse detected
+if test/specrunner 'Content-Disposition: bar' /foo; then
+    exit 1
+fi
+
+

--- a/test/specrunner.c
+++ b/test/specrunner.c
@@ -13,16 +13,17 @@ int main(int argc, char **argv) {
   char *path = argv[2];
 
   header_spec *parsed = NULL;
-  parse_spec(spec, &parsed);
-
-  if(parsed) printf("parsed has been assigned\n");
+  if(!parse_spec(spec, &parsed)) {
+    printf("Bad parse\n");
+    return 1;
+  }
 
   struct curl_slist *headers = NULL; //malloc(sizeof(struct curl_slist));
   add_matching_headers(add_header,&headers,parsed,path);
 
   struct curl_slist *onestr = headers;
   while(onestr) {
-    printf("Header is %s\n",onestr->data);
+    printf("%s\n",onestr->data);
     onestr = onestr->next;
   }
 

--- a/test/specrunner.c
+++ b/test/specrunner.c
@@ -3,8 +3,10 @@
 #include "../headerspec.h"
 #include "../cloudfsapi.h"
 
-int main(int argc, char **argv) {
-  if(argc != 3) {
+int main(int argc, char **argv)
+{
+  if(argc != 3)
+  {
     printf("Usage: %s <specscript> <path>\n", argv[0]);
     exit(1);
   }
@@ -13,16 +15,18 @@ int main(int argc, char **argv) {
   char *path = argv[2];
 
   header_spec *parsed = NULL;
-  if(!parse_spec(spec, &parsed)) {
+  if(!parse_spec(spec, &parsed))
+  {
     printf("Bad parse\n");
     return 1;
   }
 
-  struct curl_slist *headers = NULL; //malloc(sizeof(struct curl_slist));
+  struct curl_slist *headers = NULL;
   add_matching_headers(add_header,&headers,parsed,path);
 
   struct curl_slist *onestr = headers;
-  while(onestr) {
+  while(onestr)
+  {
     printf("%s\n",onestr->data);
     onestr = onestr->next;
   }

--- a/test/specrunner.c
+++ b/test/specrunner.c
@@ -22,7 +22,7 @@ int main(int argc, char **argv)
   }
 
   struct curl_slist *headers = NULL;
-  add_matching_headers(add_header,&headers,parsed,path);
+  add_matching_headers(&headers,parsed,path);
 
   struct curl_slist *onestr = headers;
   while(onestr)

--- a/test/specrunner.c
+++ b/test/specrunner.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "../headerspec.h"
+#include "../cloudfsapi.h"
+
+int main(int argc, char **argv) {
+  if(argc != 3) {
+    printf("Usage: %s <specscript> <path>\n", argv[0]);
+    exit(1);
+  }
+
+  char *spec = argv[1];
+  char *path = argv[2];
+
+  header_spec *parsed = NULL;
+  parse_spec(spec, &parsed);
+
+  if(parsed) printf("parsed has been assigned\n");
+
+  struct curl_slist *headers = NULL; //malloc(sizeof(struct curl_slist));
+  add_matching_headers(add_header,&headers,parsed,path);
+
+  struct curl_slist *onestr = headers;
+  while(onestr) {
+    printf("Header is %s\n",onestr->data);
+    onestr = onestr->next;
+  }
+
+  free_spec(parsed);
+  return 0;
+}


### PR DESCRIPTION
There is not a way currently to send user-defined headers when a file is PUT to the object store.  Most notably, Content-Type can't be controlled and is instead guessed at the server or sent as application/octet-stream, which can break static web sites hosted on CDN.  Currently, CloudFiles supports 14 headers to modify CDN behavior, but cloudfuse has no mechanism for making use of these headers.

A header specification is a mount option that can send (or omit) any number of user-defined headers, based on matches (or non-matches) on the path name.  The specification looks like:

    HeaderKey: GlobPattern HeaderValue [, GlobPattern HeaderValue...] [; HeaderKey...]

For example:

    Content-Type: *.jpg image/jpeg, ! *.txt text/html; Content-Disposition: * "attachment; filename=foo.txt"

See the README for more details.  Unit tests are included via a new 'make tests' target.  Thanks for considering accepting these changes.