### PR TITLE
control: list libjson-c-dev in Build-Depends.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: cloudfuse
 Section: utils
 Priority: optional
 Maintainer: Mike Mestnik <cheako+apt_repo@mikemestnik.net>
-Build-Depends: debhelper (>= 8.0.0), autotools-dev, libcurl4-openssl-dev, libxml2-dev, libssl-dev, libfuse-dev
+Build-Depends: debhelper (>= 8.0.0), autotools-dev, libcurl4-openssl-dev, libxml2-dev, libssl-dev, libfuse-dev, libjson-c-dev
 Standards-Version: 3.9.2
 #Vcs-Git: git://git.debian.org/collab-maint/cloudfuse.git
 #Vcs-Browser: http://git.debian.org/?p=collab-maint/cloudfuse.git;a=summary


### PR DESCRIPTION
Since json is used now, libjson-c-dev should be listed in the Build-Depends of Debian control file.
My 2 cents.
Thanks.