### PR TITLE
- Fixed Null pointer error when using ls on bucket

### DIFF
--- a/cloudfsapi.c
+++ b/cloudfsapi.c
@@ -34,6 +34,7 @@ static int curl_pool_count = 0;
 static int debug = 0;
 static int verify_ssl = 1;
 static int rhel5_mode = 0;
+static char gprefix[1024] = "";
 
 struct json_payload {
   char *data;
@@ -419,8 +420,8 @@ int cloudfs_list_directory(const char *path, dir_entry **dir_list)
       prefix_length++;
     }
 
-    snprintf(container, sizeof(container), "%s?format=xml&delimiter=/&prefix=%s%s",
-              encoded_container, encoded_object, trailing_slash);
+    snprintf(container, sizeof(container), "%s?format=xml&delimiter=/&prefix=%s%s%s",
+              encoded_container, encoded_object, trailing_slash,gprefix);
     curl_free(encoded_container);
     curl_free(encoded_object);
   }
@@ -448,6 +449,7 @@ int cloudfs_list_directory(const char *path, dir_entry **dir_list)
         de->last_modified = time(NULL);
         if (is_container || is_subdir)
           de->content_type = strdup("application/directory");
+          else de->content_type = NULL;
         for (anode = onode->children; anode; anode = anode->next)
         {
           char *content = "<?!?>";
@@ -563,6 +565,11 @@ off_t cloudfs_file_size(int fd)
 void cloudfs_debug(int dbg)
 {
   debug = dbg;
+}
+
+void cloudfs_set_prefix(char *p)
+{
+  memcpy(&gprefix,p,1024);
 }
 
 void cloudfs_verify_ssl(int vrfy)

--- a/cloudfsapi.h
+++ b/cloudfsapi.h
@@ -39,6 +39,7 @@ off_t cloudfs_file_size(int fd);
 void cloudfs_debug(int dbg);
 void cloudfs_verify_ssl(int dbg);
 void cloudfs_free_dir_list(dir_entry *dir_list);
+void cloudfs_set_prefix(char *p);
 
 void debugf(char *fmt, ...);
 #endif

--- a/cloudfuse.c
+++ b/cloudfuse.c
@@ -434,6 +434,7 @@ static struct options {
     char region[OPTION_SIZE];
     char use_snet[OPTION_SIZE];
     char verify_ssl[OPTION_SIZE];
+    char prefix[OPTION_SIZE];
 } options = {
     .username = "",
     .password = "",
@@ -443,6 +444,7 @@ static struct options {
     .region = "",
     .use_snet = "false",
     .verify_ssl = "true",
+    .prefix = ""
 };
 
 int parse_option(void *data, const char *arg, int key, struct fuse_args *outargs)
@@ -456,7 +458,8 @@ int parse_option(void *data, const char *arg, int key, struct fuse_args *outargs
       sscanf(arg, " authurl = %[^\r\n ]", options.authurl) ||
       sscanf(arg, " region = %[^\r\n ]", options.region) ||
       sscanf(arg, " use_snet = %[^\r\n ]", options.use_snet) ||
-      sscanf(arg, " verify_ssl = %[^\r\n ]", options.verify_ssl))
+      sscanf(arg, " verify_ssl = %[^\r\n ]", options.verify_ssl) ||
+      sscanf(arg, " prefix = %[^\r\n ]", options.prefix))
     return 0;
   if (!strcmp(arg, "-f") || !strcmp(arg, "-d") || !strcmp(arg, "debug"))
     cloudfs_debug(1);
@@ -496,6 +499,7 @@ int main(int argc, char **argv)
     fprintf(stderr, "  use_snet=[True to use Rackspace ServiceNet for connections]\n");
     fprintf(stderr, "  cache_timeout=[Seconds for directory caching, default 600]\n");
     fprintf(stderr, "  verify_ssl=[False to disable SSL cert verification]\n");
+    fprintf(stderr, "  prefix=[show files starting with prefix]\n");
 
     return 1;
   }
@@ -503,6 +507,8 @@ int main(int argc, char **argv)
   cloudfs_init();
 
   cloudfs_verify_ssl(!strcasecmp(options.verify_ssl, "true"));
+
+  cloudfs_set_prefix(options.prefix);
 
   cloudfs_set_credentials(options.username, options.tenant, options.password,
                           options.authurl, options.region,


### PR DESCRIPTION
- Added extra option prefix to allow user view specific part of bucket files (no support for markers and I am not sure that they work with radosgw on OpenStack)
- Fixed Null pointer in cloud_list_directory